### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # webcl-fs-20
 Module Web Clients FS 20
+
+## week 1
+Note that todo items are not yet created:
+[Todo View](https://webengineering-fhnw.github.io/webcl-fs-20/week1/todo/View.html)


### PR DESCRIPTION
added week 1 to the README.md file, with the expectation that webcl-fs-20 content will be hosted in the https://webengineering-fhnw.github.io/webcl-fs-20 github page context